### PR TITLE
fix: update API gateway URL after stack recreation

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -200,7 +200,7 @@ function Build-CLI {
 # Knowledge base & embedding model
 # ---------------------------------------------------------------------------
 
-$KB_API_URL = "https://2knihjo39k.execute-api.us-east-1.amazonaws.com/dev/kb/presigned-url"
+$KB_API_URL = "https://5ytsk24aud.execute-api.us-east-1.amazonaws.com/dev/kb/presigned-url"
 $KB_SIMULATOR = "isaac_sim"
 
 function Install-KnowledgeBase {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -169,7 +169,7 @@ build() {
 # Knowledge base & embedding model
 # ---------------------------------------------------------------------------
 
-KB_API_URL="https://2knihjo39k.execute-api.us-east-1.amazonaws.com/dev/kb/presigned-url"
+KB_API_URL="https://5ytsk24aud.execute-api.us-east-1.amazonaws.com/dev/kb/presigned-url"
 KB_SIMULATOR="isaac_sim"
 
 setup_kb() {

--- a/src/services/telemetry/SessionDataExporter.ts
+++ b/src/services/telemetry/SessionDataExporter.ts
@@ -19,7 +19,7 @@ import type { SessionLoggingLevel } from "@shared/TelemetrySetting"
  *
  * If either env var is missing, the exporter is a no-op.
  */
-const DEFAULT_INGEST_URL = "https://2knihjo39k.execute-api.us-east-1.amazonaws.com/dev/sessions"
+const DEFAULT_INGEST_URL = "https://5ytsk24aud.execute-api.us-east-1.amazonaws.com/dev/sessions"
 const DEFAULT_INGEST_KEY = "b12b2c95cd5165a6e1464c089486ec352ca03a1e688fddc11e22b492c20d2d91"
 
 export class SessionDataExporter {


### PR DESCRIPTION
## Summary
- Update API gateway URL from `2knihjo39k` to `5ytsk24aud` after the API stack was recreated

## Test plan
- [ ] Verify telemetry ingest still works with new URL
- [ ] Verify KB presigned URL endpoint works

🤖 Generated with [Claude Code](https://claude.com/claude-code)