### PR TITLE
Add client_id, cli_version, and model_id to session payload

### DIFF
--- a/src/services/telemetry/SessionDataExporter.ts
+++ b/src/services/telemetry/SessionDataExporter.ts
@@ -4,6 +4,8 @@ import type { HistoryItem } from "@shared/HistoryItem"
 import { Session } from "@shared/services/Session"
 import { Logger } from "@shared/services/Logger"
 import type { SessionLoggingLevel } from "@shared/TelemetrySetting"
+import { nanoid } from "nanoid"
+import { ExtensionRegistryInfo } from "@/registry"
 
 /**
  * Exports chat session data via direct HTTPS POST on task completion.
@@ -51,6 +53,9 @@ export class SessionDataExporter {
 			session_id: sessionId,
 			task_id: taskId,
 			ulid: ulid ?? "",
+			client_id: this.getOrCreateClientId(),
+			cli_version: ExtensionRegistryInfo.version,
+			model_id: historyItem?.modelId ?? "",
 			timestamp: new Date().toISOString(),
 			metadata: this.buildMetadata(historyItem),
 		}
@@ -73,6 +78,20 @@ export class SessionDataExporter {
 			cache_reads: historyItem.cacheReads,
 			total_cost: historyItem.totalCost,
 			model_id: historyItem.modelId,
+		}
+	}
+
+	private getOrCreateClientId(): string {
+		try {
+			const stateManager = StateManager.get()
+			let clientId = stateManager.getGlobalStateKey("clientId")
+			if (!clientId) {
+				clientId = nanoid()
+				stateManager.setGlobalState("clientId", clientId)
+			}
+			return clientId
+		} catch {
+			return ""
 		}
 	}
 
@@ -118,6 +137,9 @@ interface SessionPayload {
 	session_id: string
 	task_id: string
 	ulid: string
+	client_id: string
+	cli_version: string
+	model_id: string
 	timestamp: string
 	metadata: SessionMetadata
 	messages?: Array<{ role: string; content: unknown }>

--- a/src/shared/storage/state-keys.ts
+++ b/src/shared/storage/state-keys.ts
@@ -90,6 +90,8 @@ const GLOBAL_STATE_FIELDS = {
 	dismissedBanners: { default: [] as Array<{ bannerId: string; dismissedAt: number }> },
 	// Path to worktree that should auto-open Cline sidebar when launched
 	worktreeAutoOpenPath: { default: undefined as string | undefined },
+	// Randomly generated client ID, fixed on first launch, included in all S3 sessions
+	clientId: { default: undefined as string | undefined },
 } satisfies FieldDefinitions
 
 // Fields that map directly to ApiHandlerOptions in @shared/api.ts


### PR DESCRIPTION
## Summary
- Generate a persistent `client_id` (nanoid) on first CLI launch, stored in global state (`~/.principia/data/globalState.json`)
- Include `client_id`, `cli_version`, and `model_id` as top-level fields in every session POST to the ingest endpoint